### PR TITLE
Update gatsby-browser.js to use onInitialClientRender hook

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-export const onClientEntry = async (_, pluginOptions = {}) => {
+export const onInitialClientRender = async (_, pluginOptions = {}) => {
   const { showInProduction, axeOptions } = {
     showInProduction: false,
     axeOptions: {},


### PR DESCRIPTION
# Purpose

The `[onClientEntry](https://www.gatsbyjs.org/docs/browser-apis/#onClientEntry)` hook executes the react-axe audit too soon, before the client app is mounted, resulting in some accidental false positives (dequelabs/react-axe#124).

Changing the hook to `[onInitialClientRender](https://www.gatsbyjs.org/docs/browser-apis/#onInitialClientRender)` waits for the initial render of the app to finish on the client before running the audit.