### PR TITLE
fix: #8 - axe.run arguments are invalid

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -5,7 +5,7 @@ export const onInitialClientRender = async (_, pluginOptions = {}) => {
   const { showInProduction, axeOptions, axeContext } = {
     showInProduction: false,
     axeOptions: {},
-    axeContext: {},
+    axeContext: undefined,
     ...pluginOptions,
   }
 


### PR DESCRIPTION
react-axe is failing, as passing an empty object makes react-axe think valid context is being passed.